### PR TITLE
ci: drop the hardcoded repo owner name

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -50,5 +50,5 @@ jobs:
                 uses: docker/build-push-action@v2
                 with:
                     file: test/container/${{ matrix.config.dockerfile }}
-                    tags: ghcr.io/dracutdevs/${{ matrix.config.tag }}
+                    tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.config.tag }}
                     push: ${{ github.event_name == 'push' ||  github.event_name == 'schedule' }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,12 +3,12 @@ on:
     schedule:
         -  cron: '30 11 * * *'   # every day at 4:40
     push:
-        branches: [ master ]
+        branches: [ main ]
         paths:
             - 'test/container/**'
             - '.github/workflows/container.yml'
     pull_request:
-        branches: [ master ]
+        branches: [ main ]
         paths:
             - 'test/container/**'
             - '.github/workflows/container.yml'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,7 +2,7 @@ name: Integration Test
 
 on:
     pull_request:
-        branches: [ master ]
+        branches: [ main ]
 
 jobs:
     basic:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
                 ]
             fail-fast: false
         container:
-            image: ghcr.io/dracutdevs/${{ matrix.container }}
+            image: ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"
@@ -69,7 +69,7 @@ jobs:
                 ]
             fail-fast: false
         container:
-            image: ghcr.io/dracutdevs/${{ matrix.container }}
+            image: ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}
             options: "--privileged -v /dev:/dev"
         steps:
             -   name: "Checkout Repository"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   lint-c:


### PR DESCRIPTION
Otherwise the image push fails with permission error.

rhel-only
Related: #1966446

---

Note: pushing this directly into the org repo, otherwise I wouldn't be able to test the *privileged* actions.