### PR TITLE
ci: add a CentOS 8 Stream job

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,6 +33,7 @@ jobs:
                     - { dockerfile: 'Dockerfile-Fedora-rawhide',    tag: 'fedora:rawhide' }
                     - { dockerfile: 'Dockerfile-OpenSuse-latest',   tag: 'opensuse:latest' }
                     - { dockerfile: 'Dockerfile-Arch',              tag: 'arch:latest' }
+                    - { dockerfile: 'Dockerfile-CentOS-8-Stream',   tag: 'centos:stream8' }
         steps:
             -   name: Check out the repo
                 uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,3 +79,44 @@ jobs:
 
             -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
                 run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}
+    centos-8-stream:
+        runs-on: ubuntu-latest
+        timeout-minutes: 45
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            matrix:
+                container: [
+                        "centos:stream8",
+                ]
+                # Disabled tests (due to dropped packages in RHEL/CentOS):
+                # 03, 04, 15: requires btrfs
+                # 14: requires dmraid
+                # 30, 31, 35, 36: requires scsi-target-utils
+                test: [
+                        "01",
+                        "02",
+                        "10",
+                        "11",
+                        "12",
+                        "13",
+                        "17",
+                        "20",
+                        "21",
+                        "40",
+                        "41",
+                        "98",
+                ]
+            fail-fast: false
+        container:
+            image: ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}
+            options: "--privileged -v /dev:/dev"
+        steps:
+            -   name: "Checkout Repository"
+                uses: actions/checkout@v2
+                with:
+                    fetch-depth: 0
+
+            -   name: "${{ matrix.container }} TEST-${{ matrix.test }}"
+                run: ./tools/test-github.sh "TEST-${{ matrix.test }}" ${{ matrix.test }}

--- a/test/container/Dockerfile-CentOS-8-Stream
+++ b/test/container/Dockerfile-CentOS-8-Stream
@@ -1,0 +1,63 @@
+FROM quay.io/centos/centos:stream8
+
+MAINTAINER https://github.com/dracutdevs/dracut
+
+ENV container docker
+LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=host -e NAME=NAME -e IMAGE=IMAGE IMAGE"
+
+RUN echo 'export DRACUT_NO_XATTR=1 KVERSION=$(cd /lib/modules; ls -1 | tail -1)' > /etc/profile.d/dracut-test.sh
+
+# FIXME: the mirrors were desynchronized at the time of writing, leading to several
+#        conflicts when installing dependencies below
+RUN sed -i -e 's/^mirrorlist=/#mirrorlist=/g' -e 's/^#baseurl=/baseurl=/g' /etc/yum.repos.d/*.repo
+
+# Install needed packages for the dracut CI container
+RUN dnf -y install epel-release && \
+    `# FIXME: this is required to work around a bug in e2fsprogs, remove when CentOS 8.5 is out` && \
+    dnf -y install dnf-plugins-core && \
+    dnf -y copr enable mrc0mmand/systemd-centos-ci-centos8 && \
+    dnf -y install e2fsprogs && \
+    `# End of FIXME` && \
+    dnf -y install --enablerepo powertools --enablerepo epel --setopt=install_weak_deps=False \
+    qemu-kvm \
+    NetworkManager \
+    asciidoc \
+    bash-completion \
+    bzip2 \
+    cryptsetup \
+    dash \
+    dbus-daemon \
+    dhcp-client \
+    dhcp-server \
+    e2fsprogs \
+    gcc \
+    git \
+    iproute \
+    iputils \
+    iscsi-initiator-utils \
+    kbd \
+    kernel \
+    kmod-devel \
+    lvm2 \
+    make \
+    mdadm \
+    nfs-utils \
+    pigz \
+    python3-imgcreate \
+    rpm-build \
+    strace \
+    sudo \
+    tar \
+    tcpdump \
+    wget \
+    which \
+    xz \
+    && dnf -y update && dnf clean all
+
+# CentOS 8 ships only qemu-kvm, but it disables the KVM accel when it's not
+# available
+RUN ln -sv /usr/libexec/qemu-kvm /usr/bin/qemu-kvm && \
+    ln -sv /usr/libexec/qemu-kvm /usr/bin/qemu-system-$(uname -m)
+
+# Set default command
+CMD ["/usr/bin/bash"]


### PR DESCRIPTION
The newly introduced Dockerfile contains a couple of FIXMEs, due to the current state of things, which we can hopefully drop soon (or after CentOS 8.5 release in case of the e2fsprogs* bug). Also, I had to disable some of the tests on C8S, since they require packages no longer present on RHEL/CentOS 8. Nevertheless, I left the Fedora job intact, which runs all the integration tests, so we still have a reasonable coverage here.

Note: again pushing directly into the org repo for correct GH Actions privileges.

\* I used my [CentOS CI repo](https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci-centos8/) with a newer e2fsprogs package to fix this, since I already use it in systemd CIs for the very same thing
