### PR TITLE
95resume: always install this module

### DIFF
--- a/modules.d/95resume/module-setup.sh
+++ b/modules.d/95resume/module-setup.sh
@@ -2,20 +2,6 @@
 
 # called by dracut
 check() {
-    swap_on_netdevice() {
-        local _dev
-        for _dev in "${swap_devs[@]}"; do
-            block_is_netdevice "$_dev" && return 0
-        done
-        return 1
-    }
-
-    # Only support resume if hibernation is currently on
-    # and no swap is mounted on a net device
-    [[ $hostonly ]] || [[ $mount_needs ]] && {
-        swap_on_netdevice || [[ "$(cat /sys/power/resume)" == "0:0" ]] && return 255
-    }
-
     return 0
 }
 


### PR DESCRIPTION
We can't always correctly decide if the resume module is needed.
So let's play safe and always include it.

see: https://github.com/dracutdevs/dracut/issues/924

RHEL-only

Resolves:#1926544

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
