### PR TITLE
(#1982099) fix(qeth_rules): check the existence of /sys/devices/qeth/*/online be…

### DIFF
--- a/modules.d/95qeth_rules/module-setup.sh
+++ b/modules.d/95qeth_rules/module-setup.sh
@@ -10,6 +10,7 @@ check() {
 
     [[ $hostonly ]] && {
         for i in /sys/devices/qeth/*/online; do
+            [ ! -f "$i" ] && continue
             read -r _online < "$i"
             [ "$_online" -eq 1 ] && return 0
         done


### PR DESCRIPTION
…forehand

On s390x KVM machines, the follow errors occurred,
    $ kdumpctl rebuild
    kdump: Rebuilding /boot/initramfs-4.18.0-321.el8.s390xkdump.img
    /usr/lib/dracut/modules.d/95qeth_rules/module-setup.sh: line 13: /sys/devices/qeth/*/online: No such file or directory
    /usr/lib/dracut/modules.d/95qeth_rules/module-setup.sh: line 13: /sys/devices/qeth/*/online: No such file or directory

because s390x KVM uses virtual devices and /sys/devices/qeth/*/online
doesn't exist. Eliminate this error by checking the existence
beforehand.

(cherry picked from commit 6c71ba4121ae64ccd13fefba68ca327ac623810f)

Resolves: #1982099

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
