### PR TITLE
(#1981251) fix(kernel-modules): detect block device's hardware driver

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -617,6 +617,27 @@ for_each_host_dev_and_slaves() {
     return 1
 }
 
+# /sys/dev/block/major:minor is symbol link to real hardware device
+# go downstream $(realpath /sys/dev/block/major:minor) to detect driver
+get_blockdev_drv_through_sys() {
+    local _block_mods=""
+    local _path
+
+    _path=$(realpath "$1")
+    while true; do
+        if [[ -L "$_path"/driver/module ]]; then
+            _mod=$(realpath "$_path"/driver/module)
+            _mod=$(basename "$_mod")
+            _block_mods="$_block_mods $_mod"
+        fi
+        _path=$(dirname "$_path")
+        if [[ $_path == '/sys/devices' ]] || [[ $_path == '/' ]]; then
+            break
+        fi
+    done
+    echo "$_block_mods"
+}
+
 # ugly workaround for the lvm design
 # There is no volume group device,
 # so, there are no slave devices for volume groups.

--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -16,9 +16,15 @@ installkernel() {
     }
 
     record_block_dev_drv() {
+
         for _mod in $(get_dev_module /dev/block/"$1"); do
             _hostonly_drvs["$_mod"]="$_mod"
         done
+
+        for _mod in $(get_blockdev_drv_through_sys "/sys/dev/block/$1"); do
+            _hostonly_drvs["$_mod"]="$_mod"
+        done
+
         ((${#_hostonly_drvs[@]} > 0)) && return 0
         return 1
     }


### PR DESCRIPTION
On hostonly mode, the platform driver is not copied blindless. There
should be a way to detect the real hardware driver, which probes a block
device.

/sys/dev/block/major:minor is a symbol link, which points to the real
device, recording the hardware stack. And those info can help to
identify the associated drivers for the hardware stack.

Signed-off-by: Pingfan Liu <piliu@redhat.com>
---
v2 -> v3:
  address shellcheck in dracut-functions.sh
v1 -> v2:
  remove local variable _extra_mod
  shorten subject

(cherry picked from commit c86f4d286000d1e76fd405560b4114537e2cbbff)

Resolves: #1981251

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
