### PR TITLE
Fix shellcheck for a0d8caa8090a78f627f26fcd9b47c4b099cbc1ba

### DIFF
--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -133,12 +133,13 @@ do_fips() {
                 BOOT_IMAGE="vmlinuz-${KERNEL}"
             elif [ -d /boot/loader/entries ]; then
                 i=0
+                # shellcheck disable=SC2012
                 for bls in $(ls -d /boot/loader/entries/*.conf | sort -rV); do
-                  ((i++))
+                  i=$((i+1))
 
-                  if [ $i -eq ${BOOT_IMAGE:-0} ] && [ -r "$bls" ]; then
+                  if [ "$i" -eq "${BOOT_IMAGE:-0}" ] && [ -r "$bls" ]; then
                       BOOT_IMAGE="$(grep -e '^linux' "$bls" | grep -o ' .*$')"
-                      BOOT_IMAGE=${BOOT_IMAGE:1}
+                      BOOT_IMAGE=${BOOT_IMAGE## }
                       break
                   fi
                 done


### PR DESCRIPTION
In modules.d/01fips/fips.sh line 137:
                  ((i++))
                  ^-----^ SC3006: In POSIX sh, standalone ((..)) is undefined.
                     ^-- SC3018: In POSIX sh, ++ is undefined.

In modules.d/01fips/fips.sh line 139:
                  if [ $i -eq ${BOOT_IMAGE:-0} ] && [ -r "$bls" ]; then
                       ^-- SC2086: Double quote to prevent globbing and word splitting.
                              ^--------------^ SC2086: Double quote to prevent globbing and word splitting.

In modules.d/01fips/fips.sh line 141:
                      BOOT_IMAGE=${BOOT_IMAGE:1}
                                 ^-------------^ SC3057: In POSIX sh, string indexing is undefined.

Related: rhbz#2050567