### PR TITLE
Draft: fix(lsinitrd): TMP_DIR doesn't exist in RHEL8

### DIFF
--- a/lsinitrd.sh
+++ b/lsinitrd.sh
@@ -182,7 +182,8 @@ list_files() {
 
 list_squash_content() {
     SQUASH_IMG="squash-root.img"
-    SQUASH_TMPFILE="$TMPDIR/initrd.root.sqsh"
+    SQUASH_TMPFILE="$(mktemp -t --suffix=.root.sqsh lsinitrd.XXXXXX)"
+    trap "rm -f '$SQUASH_TMPFILE'" EXIT
 
     $CAT "$image" 2> /dev/null | cpio --extract --verbose --quiet --to-stdout -- \
         $SQUASH_IMG > "$SQUASH_TMPFILE" 2> /dev/null


### PR DESCRIPTION
QUESTION: is this needed on RHEL9 as well?
If yes, bug clone is needed: https://bugzilla.redhat.com/show_bug.cgi?id=1991647

_ _ _ _


lsinitrd should create a seperate temp file for extracting squash image
when squash module is enabled.

Signed-off-by: Kairui Song <kasong@redhat.com>
(cherry picked from commit 52fcd3373f0cf715b3744f832643dc3170aefbf5)

_Resolves: #1991647_
