### PR TITLE
(#1991823) fix(network-manager):  write DHCP filename option to dhcpopts file 

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo dbus
+    echo dbus bash
     return 0
 }
 

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 type source_hook > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
@@ -24,11 +24,45 @@ if [ -s /run/NetworkManager/initrd/hostname ]; then
     cat /run/NetworkManager/initrd/hostname > /proc/sys/kernel/hostname
 fi
 
+kf_get_string() {
+    # NetworkManager writes keyfiles (glib's GKeyFile API). Have a naive
+    # parser for it.
+    #
+    # But GKeyFile will backslash escape certain keys (\s, \t, \n) but also
+    # escape backslash. As an approximation, interpret the string with printf's
+    # '%b'.
+    #
+    # This is supposed to mimic g_key_file_get_string() (poorly).
+
+    v1="$(sed -n "s/^$1=/=/p" | sed '1!d')"
+    test "$v1" = "${v1#=}" && return 1
+    printf "%b" "${v1#=}"
+}
+
+kf_unescape() {
+    # Another layer of unescaping. While values in GKeyFile format
+    # are backslash escaped, the original strings (which are in no
+    # defined encoding) are backslash escaped too to be valid UTF-8.
+    # This will undo the second layer of escaping to give binary "strings".
+    printf "%b" "$1"
+}
+
+kf_parse() {
+    v3="$(kf_get_string "$1")" || return 1
+    v3="$(kf_unescape "$v3")"
+    printf '%s=%s\n' "$2" "$(printf '%q' "$v3")"
+}
+
+dhcpopts_create() {
+    kf_parse root-path new_root_path < "$1"
+    kf_parse next-server new_next_server < "$1"
+}
+
 for _i in /sys/class/net/*; do
-    state=/run/NetworkManager/devices/$(cat "$_i"/ifindex)
-    grep -q connection-uuid= "$state" 2> /dev/null || continue
-    ifname=${_i##*/}
-    sed -n 's/root-path/new_root_path/p;s/next-server/new_next_server/p' < "$state" > /tmp/dhclient."$ifname".dhcpopts
+    state="/run/NetworkManager/devices/$(cat "$_i"/ifindex)"
+    grep -q '^connection-uuid=' "$state" 2> /dev/null || continue
+    ifname="${_i##*/}"
+    dhcpopts_create "$state" > /tmp/dhclient."$ifname".dhcpopts
     source_hook initqueue/online "$ifname"
     /sbin/netroot "$ifname"
 done

--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -56,6 +56,7 @@ kf_parse() {
 dhcpopts_create() {
     kf_parse root-path new_root_path < "$1"
     kf_parse next-server new_next_server < "$1"
+    kf_parse dhcp-bootfile filename < "$1"
 }
 
 for _i in /sys/class/net/*; do


### PR DESCRIPTION
I've added dependent commit as well:
```
fix(network-manager): ensure safe content of /tmp/dhclient."$ifname".dhcpopts
```