### PR TITLE
fix(kernel-modules): always include nvmem driver on nvmem_on_arm

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -85,6 +85,7 @@ installkernel() {
                 "=drivers/mfd" \
                 "=drivers/mmc/core" \
                 "=drivers/mmc/host" \
+                "=drivers/nvmem" \
                 "=drivers/phy" \
                 "=drivers/power" \
                 "=drivers/regulator" \


### PR DESCRIPTION
These drivers are needed to boot on some SoCs like NXP i.MX
We should include them so installation images will work.

(cherry picked from commit bc965cd8890013a6362733d217c18756134bbcdf)

Resolves: #2109498

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
