### PR TITLE
fix(squash): build ld cache for squash loader

### DIFF
--- a/dracut-init.sh
+++ b/dracut-init.sh
@@ -504,6 +504,20 @@ inst_rules_wildcard() {
     [[ $_found ]] || dinfo "Skipping udev rule: $_rule"
 }
 
+# make sure that library links are correct and up to date
+build_ld_cache() {
+    for f in "$dracutsysrootdir"/etc/ld.so.conf "$dracutsysrootdir"/etc/ld.so.conf.d/*; do
+        [[ -f $f ]] && inst_simple "${f#$dracutsysrootdir}"
+    done
+    if ! $DRACUT_LDCONFIG -r "$initdir" -f /etc/ld.so.conf; then
+        if [[ $EUID == 0 ]]; then
+            derror "ldconfig exited ungracefully"
+        else
+            derror "ldconfig might need uid=0 (root) for chroot()"
+        fi
+    fi
+}
+
 prepare_udev_rules() {
     if [ -z "$UDEVVERSION" ]; then
         UDEVVERSION=$(udevadm --version)

--- a/dracut.sh
+++ b/dracut.sh
@@ -2360,16 +2360,7 @@ fi
 
 if [[ $kernel_only != yes ]]; then
     # make sure that library links are correct and up to date
-    for f in "$dracutsysrootdir"/etc/ld.so.conf "$dracutsysrootdir"/etc/ld.so.conf.d/*; do
-        [[ -f $f ]] && inst_simple "${f#$dracutsysrootdir}"
-    done
-    if ! $DRACUT_LDCONFIG -r "$initdir" -f /etc/ld.so.conf; then
-        if [[ $EUID == 0 ]]; then
-            derror "ldconfig exited ungracefully"
-        else
-            derror "ldconfig might need uid=0 (root) for chroot()"
-        fi
-    fi
+    build_ld_cache
 fi
 
 if dracut_module_included "squash"; then

--- a/modules.d/99squash/module-setup.sh
+++ b/modules.d/99squash/module-setup.sh
@@ -28,11 +28,6 @@ installpost() {
         [[ $squash_dir == "$i"/* ]] || mv "$i" "$squash_dir"/
     done
 
-    # initdir also needs ld.so.* to make ld.so work
-    inst /etc/ld.so.cache
-    inst /etc/ld.so.conf
-    inst_dir /etc/ld.so.conf.d
-
     # Create mount points for squash loader
     mkdir -p "$initdir"/squash/
     mkdir -p "$squash_dir"/squash/
@@ -67,6 +62,9 @@ installpost() {
     ln_r /usr/bin /bin
     ln_r /usr/sbin /sbin
     inst_simple "$moddir"/init-squash.sh /init
+
+    # make sure that library links are correct and up to date for squash loader
+    build_ld_cache
 }
 
 install() {


### PR DESCRIPTION
Commit dc21638c3f0a fixes kdump kernel crash, due to non-conventional
library path in powerpc, by copying /etc/ld.so.cache under initdir.
While that works in general, it is vulnerable to failure because of
missing links, when the CPU is reconfigured to run in compatibility
mode of older CPU version. Avoid this by running ldconfig for squash
loader to create the necessary links & ld cache for it. Doing this
also saves a few kilobyes of space as the copied ld cache is bigger
in size than the one needed for squash loader environment.

Fixes: dc21638c3f0a ("fix(squash): keep ld cache under initdir")
Cc: Pingfan Liu <piliu@redhat.com>
Signed-off-by: Hari Bathini <hbathini@linux.ibm.com>

Resolves: rhbz#2122274

_ _ _ _ 
Not merged upstream yet.