### PR TITLE
fix(90kernel-modules): always install nvdimm drivers

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -56,6 +56,8 @@ installkernel() {
             "=drivers/tty/serial" \
             "=drivers/input/serio" \
             "=drivers/input/keyboard" \
+            "=drivers/nvdimm/nd_pmem" \
+            "=drivers/nvdimm/nd_btt" \
             "=drivers/pci/host" \
             "=drivers/pci/controller" \
             "=drivers/pinctrl" \


### PR DESCRIPTION
nd_pmem and nd_btt

Corresponding kernel symbol blk_cleanup_disk was removed and calls are made directly instead.

Resolves: #2149781