### PR TITLE
fix(90kernel-modules): install blk modules using symbol blk_alloc_disk

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 installkernel() {
-    local _blockfuncs='ahci_platform_get_resources|ata_scsi_ioctl|scsi_add_host|blk_cleanup_queue|register_mtd_blktrans|scsi_esp_register|register_virtio_device|usb_stor_disconnect|mmc_add_host|sdhci_add_host|scsi_add_host_with_dma|blk_mq_alloc_disk|blk_cleanup_disk'
+    local _blockfuncs='ahci_platform_get_resources|ata_scsi_ioctl|scsi_add_host|blk_cleanup_queue|register_mtd_blktrans|scsi_esp_register|register_virtio_device|usb_stor_disconnect|mmc_add_host|sdhci_add_host|scsi_add_host_with_dma|blk_alloc_disk|blk_mq_alloc_disk|blk_cleanup_disk'
     local -A _hostonly_drvs
 
     find_kernel_modules_external() {


### PR DESCRIPTION
Corresponding kernel symbol blk_cleanup_disk is no longer used in the nvdimm driver and calls are made directly instead.

blk_alloc_disk is used:
https://elixir.bootlin.com/linux/v6.1-rc8/source/drivers/nvdimm/pmem.c#L522

Resolves: #2149781