### PR TITLE
Allow running nm-run.sh multiple times.

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -2,11 +2,12 @@
 
 type source_hook > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if [ -e /tmp/nm.done ]; then
-    return
-fi
-
 if [ -z "$DRACUT_SYSTEMD" ]; then
+
+    if [ -e /tmp/nm.done ]; then
+        return
+    fi
+
     # Only start NM if networking is needed
     if [ -e /run/NetworkManager/initrd/neednet ]; then
         for i in /usr/lib/NetworkManager/system-connections/* \


### PR DESCRIPTION
This partially reverts
https://github.com/redhat-plumbers/dracut-rhel9/commit/77630365aed201a729c73a9ffda0733a75f3fee4

Anaconda needs to be able to run nm-run.sh to trigger online hooks again after kickstart is fetched from storage and network is configured accordingly.

Related: rhbz#2153361