### PR TITLE
Ignore lo network connection when running online hooks

### DIFF
--- a/modules.d/35network-manager/nm-run.sh
+++ b/modules.d/35network-manager/nm-run.sh
@@ -64,6 +64,7 @@ for _i in /sys/class/net/*; do
     state="/run/NetworkManager/devices/$(cat "$_i"/ifindex)"
     grep -q '^connection-uuid=' "$state" 2> /dev/null || continue
     ifname="${_i##*/}"
+    [ "$ifname" == "lo" ] && continue
     dhcpopts_create "$state" > /tmp/dhclient."$ifname".dhcpopts
     source_hook initqueue/online "$ifname"
     /sbin/netroot "$ifname"


### PR DESCRIPTION
The connection appears in initramfs since
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/1332

Related: rhbz#2153361
