### PR TITLE
feat(hwdb): install hwdb on demand when module is needed

### DIFF
--- a/modules.d/95hwdb/module-setup.sh
+++ b/modules.d/95hwdb/module-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This file is part of dracut.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+check() {
+    return 255
+}
+
+# called by dracut
+install() {
+    local hwdb_bin
+
+    # systemd-hwdb ships the file in /etc, with /usr/lib as an alternative.
+    # Therefore consider this location as preferred for configuration.
+    hwdb_bin="${udevdir}"/hwdb.bin
+
+    if [[ ! -r "${hwdb_bin}" ]]; then
+      hwdb_bin="${udevconfdir}"/hwdb.bin
+    fi
+
+    if [[ $hostonly ]]; then
+        inst_multiple -H "${hwdb_bin}"
+    else
+        inst_multiple "${hwdb_bin}"
+    fi
+}

--- a/pkgbuild/dracut.spec
+++ b/pkgbuild/dracut.spec
@@ -367,6 +367,7 @@ echo 'dracut_rescue_image="yes"' > $RPM_BUILD_ROOT%{dracutlibdir}/dracut.conf.d/
 %{dracutlibdir}/modules.d/91tpm2-tss
 %{dracutlibdir}/modules.d/95debug
 %{dracutlibdir}/modules.d/95fstab-sys
+%{dracutlibdir}/modules.d/95hwdb
 %{dracutlibdir}/modules.d/95lunmask
 %{dracutlibdir}/modules.d/95nvmf
 %{dracutlibdir}/modules.d/95resume


### PR DESCRIPTION
Adding a module to install hwdb. Further extensions might make only selected part of hwdb installable, to save space. The module is not included by default.

Including the module adds 2MB of compressed data (on Fedora, the file has 12MB).

hwdb is needed in case of custom HW, like a keyboard/mouse or various interfaces.

Original PR: https://github.com/dracutdevs/dracut/pull/1681

(Cherry-picked commit: 062e739d89543a38d4b3e2cab155912bc4bf9e56)

Resolves: #2233597

_ _ _ _ 

Clone for https://github.com/redhat-plumbers/dracut-rhel8/commit/62fb051db129a1cbb5645107933e961a57d8bef3