### PR TITLE
fix(fips): do not blindly remove /boot

### DIFF
--- a/modules.d/01fips/fips-boot.sh
+++ b/modules.d/01fips/fips-boot.sh
@@ -8,7 +8,9 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif getarg boot= > /dev/null; then
     . /sbin/fips.sh
+    fips_info "fips-boot: start"
     if mount_boot; then
         do_fips || die "FIPS integrity test failed"
     fi
+    fips_info "fips-boot: done!"
 fi

--- a/modules.d/01fips/fips-load-crypto.sh
+++ b/modules.d/01fips/fips-load-crypto.sh
@@ -8,5 +8,7 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 else
     . /sbin/fips.sh
+    fips_info "fips-load-crypto: start"
     fips_load_crypto || die "FIPS integrity test failed"
+    fips_info "fips-load-crypto: done!"
 fi

--- a/modules.d/01fips/fips-noboot.sh
+++ b/modules.d/01fips/fips-noboot.sh
@@ -8,6 +8,8 @@ elif [ -z "$fipsmode" ]; then
     die "FIPS mode have to be enabled by 'fips=1' not just 'fips'"
 elif ! [ -f /tmp/fipsdone ]; then
     . /sbin/fips.sh
+    fips_info "fips-noboot: start"
     mount_boot
     do_fips || die "FIPS integrity test failed"
+    fips_info "fips-noboot: done!"
 fi

--- a/modules.d/01fips/fips.sh
+++ b/modules.d/01fips/fips.sh
@@ -18,6 +18,15 @@ mount_boot() {
     boot=$(getarg boot=)
 
     if [ -n "$boot" ]; then
+        if [ -d /boot ] && ismounted /boot; then
+            boot_dev=
+            if command -v findmnt > /dev/null; then
+                boot_dev=$(findmnt -n -o SOURCE /boot)
+            fi
+            fips_info "Ignoring 'boot=$boot' as /boot is already mounted ${boot_dev:+"from '$boot_dev'"}"
+            return 0
+        fi
+
         case "$boot" in
             LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
                 boot="$(label_uuid_to_dev "$boot")"
@@ -47,10 +56,13 @@ mount_boot() {
         mkdir -p /boot
         fips_info "Mounting $boot as /boot"
         mount -oro "$boot" /boot || return 1
-    elif [ -d "$NEWROOT/boot" ]; then
+        FIPS_MOUNTED_BOOT=1
+    elif ! ismounted /boot && [ -d "$NEWROOT/boot" ]; then
         # shellcheck disable=SC2114
         rm -fr -- /boot
         ln -sf "$NEWROOT/boot" /boot
+    else
+        die "You have to specify boot=<boot device> as a boot option for fips=1"
     fi
 }
 
@@ -179,7 +191,12 @@ do_fips() {
 
     : > /tmp/fipsdone
 
-    umount /boot > /dev/null 2>&1
+    if [ "$FIPS_MOUNTED_BOOT" = 1 ]; then
+        fips_info "Unmounting /boot"
+        umount /boot > /dev/null 2>&1
+    else
+        fips_info "Not unmounting /boot"
+    fi
 
     return 0
 }

--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -62,7 +62,7 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_hook pre-mount 01 "$moddir/fips-boot.sh"
+    inst_hook pre-pivot 00 "$moddir/fips-boot.sh"
     inst_hook pre-pivot 01 "$moddir/fips-noboot.sh"
     inst_hook pre-udev 01 "$moddir/fips-load-crypto.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh


### PR DESCRIPTION
The `mount_boot` method called from fips-noboot.sh in the pre-pivot hook blindly
executes `rm -rf /boot` if there is no `boot=` command line parameter, without
first checking that /boot is not already mounted by other means.

feat(fips): add progress messages

This allows to better understand at what point a FIPS integrity test failed.

Signed-off-by: Raymund Will <rw@suse.com>

fix(fips): only unmount /boot if it was mounted by the fips module

The `do_fips` method should only unmount /boot if it was mounted in the
`mount_boot` method.

In addition, now the `mount_boot` method checks if /boot is already mounted.

Signed-off-by: Raymund Will <rw@suse.com>

fix(fips): move fips-boot script to pre-pivot

This is needed in s390x to be able to use the same `boot=` command line
parameter in grub and zipl. Otherwise, `boot=` would need to be added only to
`grub.cfg` (not `/etc/default/grub` and thereby not to `/boot/zipl/config`).

Signed-off-by: Raymund Will <rw@suse.com>

(Cherry-picked commits:
  91974e8ff116c7fd9f99963780dba501535700f5
  a71e518fa1f14a9b96ae62ce90714ccd7d307d97
  1cdb4cb8b5fb7f74e5be6998f9b561fbf73909e0
  cd2a1d4571b2f768f2b67d03fd77191795042402)

Resolves: RHEL-45913
