### PR TITLE
(RHEL-30581) ci: remove non-existing modules from labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -50,9 +50,6 @@ bash:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/00bash/*'
 
-bootchart:
-  - modules.d/00bootchart/*
-
 dash:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/00dash/*'
@@ -344,9 +341,6 @@ qemu:
 qemu-net:
   - changed-files:
     - any-glob-to-any-file: 'modules.d/90qemu-net/*'
-
-stratis:
-  - modules.d/90stratis/*
 
 crypt-gpg:
   - changed-files:


### PR DESCRIPTION
(cherry picked from commit 1d60dd74ee721f17cdaadd56b874b564b89c0145)

Related: RHEL-30581

follow-up to https://github.com/redhat-plumbers/dracut-rhel9/pull/81


<!-- issue-commentator = {"comment-id":"2233548550"} -->