### PR TITLE
(RHEL-52326) fix(nfs): include also entries from /usr/lib/{passwd,group}

### DIFF
--- a/modules.d/95nfs/module-setup.sh
+++ b/modules.d/95nfs/module-setup.sh
@@ -130,8 +130,16 @@ install() {
 
     # Rather than copy the passwd file in, just set a user for rpcbind
     # We'll save the state and restart the daemon from the root anyway
-    grep -E '^nfsnobody:|^rpc:|^rpcuser:' "$dracutsysrootdir"/etc/passwd >> "$initdir/etc/passwd"
-    grep -E '^nogroup:|^rpc:|^nobody:' "$dracutsysrootdir"/etc/group >> "$initdir/etc/group"
+
+    local _confdir
+    for _confdir in etc usr/lib; do
+
+        grep -sE '^(nfsnobody|_rpc|rpc|rpcuser):' "${dracutsysrootdir}/${_confdir}/passwd" \
+            >> "$initdir/${_confdir}/passwd"
+
+        grep -sE '^(nogroup|rpc|nobody):' "${dracutsysrootdir}/${_confdir}/group" \
+            >> "$initdir/${_confdir}/group"
+    done
 
     # rpc user needs to be able to write to this directory to save the warmstart
     # file


### PR DESCRIPTION
as those paths are used by bootc instead of the /etc ones.

(cherry picked from commit 45cdf3c4f24f77f04b264a7747f115d1031b2e67)

Resolves: RHEL-52326



<!-- issue-commentator = {"comment-id":"2282727021"} -->