### PR TITLE
(RHEL-53114) fix(systemd): set right permissions for the machine-id file

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -194,6 +194,7 @@ install() {
 
     if ! [[ -e "$initdir/etc/machine-id" ]]; then
         : > "$initdir/etc/machine-id"
+        chmod 444 "$initdir/etc/machine-id"
     fi
 
     # install adm user/group for journald


### PR DESCRIPTION
(cherry picked from commit 455dbb585583bd2e1d40ebb61c335a2ad6dff053)

Resolves: RHEL-53114


<!-- issue-commentator = {"comment-id":"2294432941"} -->