### PR TITLE
(RHEL-64754) fix(35network-manager): install nft binary during module installation

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -37,7 +37,7 @@ install() {
     inst NetworkManager
     inst_multiple -o /usr/{lib,libexec}/nm-initrd-generator
     inst_multiple -o /usr/{lib,libexec}/nm-daemon-helper
-    inst_multiple -o teamd dhclient
+    inst_multiple -o teamd dhclient nft
     inst_hook cmdline 99 "$moddir/nm-config.sh"
     if dracut_module_included "systemd"; then
 

--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -20,6 +20,11 @@ installkernel() {
 }
 
 # called by dracut
+installkernel() {
+    instmods nf_tables nfnetlink nft_fwd_netdev
+}
+
+# called by dracut
 install() {
     local _nm_version
 


### PR DESCRIPTION
- fix(35network-manager): install nftables kernel modules needed
- fix(35network-manager): install nft binary during module installation
  Resolves: RHEL-64754


<!-- issue-commentator = {"comment-id":"2504355983"} -->