### PR TITLE
(RHEL-55708) rhel 9 fix 55708

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -971,8 +971,20 @@ block_is_netdevice() {
 get_dev_module() {
     local dev_attr_walk
     local dev_drivers
+    local dev_paths
     dev_attr_walk=$(udevadm info -a "$1")
     dev_drivers=$(echo "$dev_attr_walk" | sed -n 's/\s*DRIVERS=="\(\S\+\)"/\1/p')
+
+    # also return modalias info from sysfs paths parsed by udevadm
+    dev_paths=$(echo "$dev_attr_walk" | sed -n 's/.*\(\/devices\/.*\)'\'':/\1/p')
+    local dev_path
+    for dev_path in $dev_paths; do
+        local modalias_file="/sys$dev_path/modalias"
+        if [ -e "$modalias_file" ]; then
+            dev_drivers="$(printf "%s\n%s" "$dev_drivers" "$(cat "$modalias_file")")"
+        fi
+    done
+
     # if no kernel modules found and device is in a virtual subsystem, follow symlinks
     if [[ -z $dev_drivers && $(udevadm info -q path "$1") == "/devices/virtual"* ]]; then
         local dev_vkernel

--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -967,13 +967,30 @@ block_is_netdevice() {
     block_is_nbd "$1" || block_is_iscsi "$1" || block_is_fcoe "$1"
 }
 
+# convert the driver name given by udevadm to the corresponding kernel module name
+get_module_name() {
+    local dev_driver
+    while read -r dev_driver; do
+        case "$dev_driver" in
+            mmcblk)
+                echo "mmc_block"
+                ;;
+            *)
+                echo "$dev_driver"
+                ;;
+        esac
+    done
+}
+
 # get the corresponding kernel modules of a /sys/class/*/* or/dev/* device
 get_dev_module() {
     local dev_attr_walk
     local dev_drivers
     local dev_paths
     dev_attr_walk=$(udevadm info -a "$1")
-    dev_drivers=$(echo "$dev_attr_walk" | sed -n 's/\s*DRIVERS=="\(\S\+\)"/\1/p')
+    dev_drivers=$(echo "$dev_attr_walk" \
+        | sed -n 's/\s*DRIVERS=="\(\S\+\)"/\1/p' \
+        | get_module_name)
 
     # also return modalias info from sysfs paths parsed by udevadm
     dev_paths=$(echo "$dev_attr_walk" | sed -n 's/.*\(\/devices\/.*\)'\'':/\1/p')
@@ -1001,6 +1018,7 @@ get_dev_module() {
                 [[ -n $dev_drivers && ${dev_drivers: -1} != $'\n' ]] && dev_drivers+=$'\n'
                 dev_drivers+=$(udevadm info -a "$dev_vpath/$dev_link" \
                     | sed -n 's/\s*DRIVERS=="\(\S\+\)"/\1/p' \
+                    | get_module_name \
                     | grep -v -e pcieport)
             done
         fi


### PR DESCRIPTION
- **fix(kernel-modules): use modalias info in get_dev_module()**
- **fix(dracut-functions.sh): convert mmcblk to the real kernel module name**


<!-- issue-commentator = {"comment-id":"2504705810"} -->