### PR TITLE
(RHEL-56885) feat(fips): add support for UKIs

### DIFF
--- a/modules.d/01fips/module-setup.sh
+++ b/modules.d/01fips/module-setup.sh
@@ -67,7 +67,7 @@ install() {
     inst_hook pre-udev 01 "$moddir/fips-load-crypto.sh"
     inst_script "$moddir/fips.sh" /sbin/fips.sh
 
-    inst_multiple sha512hmac rmmod insmod mount uname umount grep sed sort
+    inst_multiple sha512hmac rmmod insmod mount uname umount grep sed cut find sort cat tail tr
 
     inst_simple /etc/system-fips
 


### PR DESCRIPTION
Kernel integrity check in FIPS module is incompatible with UKIs as neither
/boot/vmlinuz-`uname-r` nor /boot/.vmlinuz-`uname-r`.hmac are present. UKI
is placed to $ESP\EFI\Linux\<install-tag>-<uname-r>.efi and if a .hmac file
is present next to it, it is possible to do similar check.

Note, UKIs have a 'one size fits all' command line and 'boot=' is not expected
to be set. Luckily, if the UKI is systemd-stub based then we can expect
'LoaderDevicePartUUID' variable containing PARTUUID of the ESP to be set. Mount
it to /boot using the existing logic.

Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>

(cherry picked from commit 72684ff519be4f29c45cbb0f84759e645b0ac4be)

Resolves: RHEL-56885


<!-- issue-commentator = {"comment-id":"2504737871"} -->