### PR TITLE
(RHEL-64754) fix(35network-manager): remove duplicate installkernel function

### DIFF
--- a/modules.d/35network-manager/module-setup.sh
+++ b/modules.d/35network-manager/module-setup.sh
@@ -16,11 +16,6 @@ depends() {
 
 # called by dracut
 installkernel() {
-    return 0
-}
-
-# called by dracut
-installkernel() {
     instmods nf_tables nfnetlink nft_fwd_netdev
 }
 


### PR DESCRIPTION
Issue introduced in commit: 0a264651d148b543c0c5d6b0a07909cdcb1abfba

Resolves: RHEL-64754


<!-- issue-commentator = {"comment-id":"2661801944"} -->