### PR TITLE
(RHEL-92584) fix(dracut.sh): don't pass empty string as dir

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -962,7 +962,7 @@ if [[ -f $conffile ]]; then
 fi
 
 # source our config dir
-for f in $(dropindirs_sort ".conf" "$confdir" "$add_confdir" "$dracutbasedir/dracut.conf.d"); do
+for f in $(dropindirs_sort ".conf" "$confdir" ${add_confdir:+"$add_confdir"} "$dracutbasedir/dracut.conf.d"); do
     check_conf_file "$f"
     # shellcheck disable=SC1090
     [[ -e $f ]] && . "$f"


### PR DESCRIPTION
That causes dropindirs_sort() to look for .conf files in / due to
expansion:

    for d in "$@"; do
        for i in "$d/"*"$suffix"; do

Fixes #1275

(cherry picked from commit 000cfa0c278c0858e81c8dd2ff7231f069f0afb1)

Resolves: RHEL-92584

<!-- issue-commentator = {"comment-id":"2956977470"} -->