### PR TITLE
rhel 9 fix 96106

### DIFF
--- a/man/dracut.cmdline.7.asc
+++ b/man/dracut.cmdline.7.asc
@@ -1383,8 +1383,6 @@ rd_NO_MD:: rd.md=0
 
 rd_MD_UUID:: rd.md.uuid
 
-rd_NO_MULTIPATH: rd.multipath=0
-
 rd_NFS_DOMAIN:: rd.nfs.domain
 
 iscsi_initiator:: rd.iscsi.initiator

--- a/modules.d/90multipath/module-setup.sh
+++ b/modules.d/90multipath/module-setup.sh
@@ -90,6 +90,7 @@ install() {
     [[ -d $config_dir ]] || config_dir=/etc/multipath/conf.d
 
     inst_multiple \
+        "$systemdsystemunitdir"/multipathd.service \
         pkill \
         pidof \
         kpartx \
@@ -137,7 +138,7 @@ install() {
             inst_simple "${moddir}/multipathd-configure.service" "${systemdsystemunitdir}/multipathd-configure.service"
             $SYSTEMCTL -q --root "$initdir" enable multipathd-configure.service
         fi
-        inst_simple "${moddir}/multipathd.service" "${systemdsystemunitdir}/multipathd.service"
+        inst_simple "$moddir/multipathd-dracut.conf" "$systemdsystemunitdir/multipathd.service.d/multipathd-dracut.conf"
         $SYSTEMCTL -q --root "$initdir" enable multipathd.service
     else
         inst_hook pre-trigger 02 "$moddir/multipathd.sh"

--- a/modules.d/90multipath/multipathd-dracut.conf
+++ b/modules.d/90multipath/multipathd-dracut.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionKernelCommandLine=!rd.multipath=0

--- a/modules.d/90multipath/multipathd.service
+++ b/modules.d/90multipath/multipathd.service
@@ -11,7 +11,6 @@ Conflicts=shutdown.target
 Conflicts=initrd-cleanup.service
 ConditionKernelCommandLine=!nompath
 ConditionKernelCommandLine=!rd.multipath=0
-ConditionKernelCommandLine=!rd_NO_MULTIPATH
 ConditionKernelCommandLine=!multipath=off
 ConditionVirtualization=!container
 

--- a/modules.d/90multipath/multipathd.sh
+++ b/modules.d/90multipath/multipathd.sh
@@ -5,7 +5,7 @@ if [ "$(getarg rd.multipath)" = "default" ] && [ ! -e /etc/multipath.conf ]; the
     mpathconf --enable
 fi
 
-if getargbool 1 rd.multipath -d -n rd_NO_MULTIPATH && [ -e /etc/multipath.conf ]; then
+if getargbool 1 rd.multipath && [ -e /etc/multipath.conf ]; then
     modprobe dm-multipath
     multipathd -B || multipathd
     need_shutdown


### PR DESCRIPTION
- **chore(multipath): remove `rd_NO_MULTIPATH` kernel command line option**
- **refactor(multipath): remove custom multipathd.service**
