### PR TITLE
(RHEL-104222) fix: let check_vol_slaves_all return 1 when checks on all slaves fail

### DIFF
--- a/dracut-functions.sh
+++ b/dracut-functions.sh
@@ -661,7 +661,7 @@ check_vol_slaves() {
 }
 
 check_vol_slaves_all() {
-    local _vg _pv _majmin
+    local _vg _pv _majmin _ret=1
     _majmin="$2"
     _dm="/sys/dev/block/$_majmin/dm"
     [[ -f $_dm/uuid && $(< "$_dm"/uuid) =~ LVM-* ]] || return 1
@@ -675,11 +675,10 @@ check_vol_slaves_all() {
         fi
 
         for _pv in $(lvm vgs --noheadings -o pv_name "$_vg" 2> /dev/null); do
-            check_block_and_slaves_all "$1" "$(get_maj_min "$_pv")"
+            check_block_and_slaves_all "$1" "$(get_maj_min "$_pv")" && _ret=0
         done
-        return 0
     fi
-    return 1
+    return $_ret
 }
 
 # fs_get_option <filesystem options> <search for option>

--- a/modules.d/95nvmf/module-setup.sh
+++ b/modules.d/95nvmf/module-setup.sh
@@ -61,6 +61,14 @@ depends() {
 installkernel() {
     instmods nvme_fc lpfc qla2xxx
     hostonly="" instmods nvme_tcp nvme_fabrics 8021q
+    # lookup NIC kernel modules for active NBFT interfaces
+    if [[ $hostonly ]]; then
+        for i in /sys/class/net/nbft*; do
+            [ -d "$i" ] || continue
+            _driver=$(basename "$(readlink -f "$i/device/driver/module")")
+            [ -z "$_driver" ] || instmods "$_driver"
+        done
+    fi
 }
 
 # called by dracut

--- a/modules.d/95nvmf/parse-nvmf-boot-connections.sh
+++ b/modules.d/95nvmf/parse-nvmf-boot-connections.sh
@@ -324,3 +324,7 @@ fi
 
 /sbin/initqueue --settled --onetime --name nvmf-connect-settled /sbin/nvmf-autoconnect.sh settled
 /sbin/initqueue --timeout --onetime --name nvmf-connect-timeout /sbin/nvmf-autoconnect.sh timeout
+
+# shellcheck disable=SC2034
+rootok=1
+[ -z "$root" ] && root="nvmf"


### PR DESCRIPTION
Currently check_vol_slaves_all return 0 even after checks on all slaves
fail. And this leads to an issue that "dracut -hostonly-mode strict"
gets stuck forever because instmods keeps waiting for user input when
it's passed empty argument in the kernel-modules module.

Fixes: c7c8c498 ("dracut-functions.sh: catch all lvm slaves")
Reported-by: Tomáš Bžatek <tbzatek@redhat.com>
Signed-off-by: Coiby Xu <coxu@redhat.com>
(cherry picked from commit 1fcfb2bffdad22873a804043eeeb9bb65a99caa8)

Resolves: RHEL-104222

<!-- issue-commentator = {"comment-id":"3165442396"} -->