### PR TITLE
(RHEL-101901) rhel 9 fix 101901

### DIFF
--- a/dracut.sh
+++ b/dracut.sh
@@ -2245,12 +2245,6 @@ for ((i = 0; i < ${#include_src[@]}; i++)); do
     fi
 done
 
-if [[ $do_hardlink == yes ]] && command -v hardlink > /dev/null; then
-    dinfo "*** Hardlinking files ***"
-    hardlink "$initdir" 2>&1 | dinfo
-    dinfo "*** Hardlinking files done ***"
-fi
-
 # strip binaries
 if [[ $do_strip == yes ]]; then
     # Prefer strip from elfutils for package size
@@ -2453,7 +2447,7 @@ if [[ $uefi == yes ]]; then
 fi
 
 clamp_mtimes() {
-    find "$1" -newer "$dracutbasedir/dracut-functions.sh" -print0 \
+    find "$@" -newer "$dracutbasedir/dracut-functions.sh" -print0 \
         | xargs -r -0 touch -h -m -c -r "$dracutbasedir/dracut-functions.sh"
 }
 
@@ -2464,6 +2458,19 @@ if [[ $DRACUT_REPRODUCIBLE ]]; then
         CPIO_REPRODUCIBLE=1
     else
         dinfo "cpio does not support '--reproducible'. Resulting image will not be reproducible."
+    fi
+fi
+
+# Hardlink is mtime-sensitive; do it after the above clamp.
+if [[ $do_hardlink == yes ]] && command -v hardlink > /dev/null; then
+    dinfo "*** Hardlinking files ***"
+    hardlink "$initdir" 2>&1 | ddebug
+    dinfo "*** Hardlinking files done ***"
+
+    # Hardlink itself breaks mtimes on directories as we may have added/removed
+    # dir entries. Fix those up.
+    if [[ $DRACUT_REPRODUCIBLE ]]; then
+        clamp_mtimes "$initdir" -type d
     fi
 fi
 

--- a/dracut.sh
+++ b/dracut.sh
@@ -2452,9 +2452,13 @@ if [[ $uefi == yes ]]; then
     mkdir -p "$uefi_outdir"
 fi
 
-if [[ $DRACUT_REPRODUCIBLE ]]; then
-    find "$initdir" -newer "$dracutbasedir/dracut-functions.sh" -print0 \
+clamp_mtimes() {
+    find "$1" -newer "$dracutbasedir/dracut-functions.sh" -print0 \
         | xargs -r -0 touch -h -m -c -r "$dracutbasedir/dracut-functions.sh"
+}
+
+if [[ $DRACUT_REPRODUCIBLE ]]; then
+    clamp_mtimes "$initdir"
 
     if [[ "$(cpio --help)" == *--reproducible* ]]; then
         CPIO_REPRODUCIBLE=1
@@ -2469,8 +2473,7 @@ if [[ $create_early_cpio == yes ]]; then
     echo 1 > "$early_cpio_dir/d/early_cpio"
 
     if [[ $DRACUT_REPRODUCIBLE ]]; then
-        find "$early_cpio_dir/d" -newer "$dracutbasedir/dracut-functions.sh" -print0 \
-            | xargs -r -0 touch -h -m -c -r "$dracutbasedir/dracut-functions.sh"
+        clamp_mtimes "$early_cpio_dir/d"
     fi
 
     # The microcode blob is _before_ the initramfs blob, not after


### PR DESCRIPTION
- **refactor(dracut): introduce clamp_mtimes helper function**
- **fix(dracut): ensure hardlink deduplication is reproducible**

<!-- issue-commentator = {"comment-id":"3168951486"} -->