### PR TITLE
(RHEL-94663) fix(systemd): partial backport of

### DIFF
--- a/modules.d/00systemd/module-setup.sh
+++ b/modules.d/00systemd/module-setup.sh
@@ -18,7 +18,7 @@ depends() {
 
 installkernel() {
     hostonly='' instmods autofs4 ipv6 algif_hash hmac sha256 sg
-    instmods -s efivarfs overlay
+    hostonly=$(optional_hostonly) instmods -s efivarfs overlay
 }
 
 # called by dracut


### PR DESCRIPTION
Author: Jo Zzsi <jozzsicsataban@gmail.com>
Date:   Wed Apr 23 19:21:59 2025 -0400

    fix: load more kernel modules in sloppy hostonly mode

    When hostonly_mode is set to "sloppy" instmods consults the host for currently loaded kernel modules and
    refuses to copy the Linux kernel module into the generated initramfs unless the kernel
    module is already loaded on the host.

    Let's set hostonly explicitly to a better default before calling instmods.

    For compatibility, we should not change the default in the instmods function itself.

(cherry picked from commit de862885ec55bb19bfa3e3f1afd27577b7c5e309)

Resolves: RHEL-94663

<!-- issue-commentator = {"comment-id":"3195655994"} -->