### PR TITLE
feat(install.d):When --entry-type=type2 is used (for UKI), will not remove normal kernel IMAGE.

### DIFF
--- a/install.d/50-dracut.install
+++ b/install.d/50-dracut.install
@@ -58,6 +58,11 @@ case "$COMMAND" in
         ret=$?
 	;;
     remove)
+        if [[ "$KERNEL_INSTALL_BOOT_ENTRY_TYPE" == "type2" ]]; then
+            [[ "${KERNEL_INSTALL_VERBOSE:-0}" -gt 0 ]] && \
+                echo "Not removing UKI image (type2); handled by systemd's 90-uki-copy.install"
+            exit 0
+        fi
         rm -f -- "$BOOT_DIR_ABS/$INITRD"
         ret=$?
 	;;


### PR DESCRIPTION
feat(install.d):When --entry-type=type2 is used (for UKI), will not remove normal kernel IMAGE.
according to the changes of https://github.com/systemd/systemd/pull/37897

Resolves: https://github.com/systemd/systemd/pull/37897