### PR TITLE
rhel 9 fix 170858

### DIFF
--- a/modules.d/35network-legacy/dhclient-script.sh
+++ b/modules.d/35network-legacy/dhclient-script.sh
@@ -48,22 +48,24 @@ setup_interface() {
     if [ -n "$gw" ]; then
         if [ "$mask" = "255.255.255.255" ]; then
             # point-to-point connection => set explicit route to gateway
-            echo ip route add "$gw" dev "$netif" > /tmp/net."$netif".gw
+            printf 'ip route add %q dev %q\n' "$gw" "$netif" > /tmp/net."$netif".gw
         fi
 
         echo "$gw" | {
             IFS=' ' read -r main_gw other_gw
-            echo ip route replace default via "$main_gw" dev "$netif" >> /tmp/net."$netif".gw
+            printf 'ip route replace default via %q dev %q\n' "$main_gw" "$netif" >> /tmp/net."$netif".gw
             if [ -n "$other_gw" ]; then
                 for g in $other_gw; do
-                    echo ip route add default via "$g" dev "$netif" >> /tmp/net."$netif".gw
+                    printf 'ip route add default via %q dev %q\n' "$g" "$netif" >> /tmp/net."$netif".gw
                 done
             fi
         }
     fi
 
     if getargbool 1 rd.peerdns; then
-        [ -n "${search}${domain}" ] && echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        if [ -n "${search}${domain}" ]; then
+            echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        fi
         if [ -n "$namesrv" ]; then
             for s in $namesrv; do
                 echo nameserver "$s"
@@ -72,7 +74,10 @@ setup_interface() {
     fi
     # Note: hostname can be fqdn OR short hostname, so chop off any
     # trailing domain name and explicity add any domain if set.
-    [ -n "$hostname" ] && echo "echo ${hostname%.$domain}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname%."$domain"}${domain:+.$domain}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
 }
 
 setup_interface6() {
@@ -95,7 +100,9 @@ setup_interface6() {
         ${preferred_lft:+preferred_lft ${preferred_lft}}
 
     if getargbool 1 rd.peerdns; then
-        [ -n "${search}${domain}" ] && echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        if [ -n "${search}${domain}" ]; then
+            echo "search $search $domain" > /tmp/net."$netif".resolv.conf
+        fi
         if [ -n "$namesrv" ]; then
             for s in $namesrv; do
                 echo nameserver "$s"
@@ -105,7 +112,10 @@ setup_interface6() {
 
     # Note: hostname can be fqdn OR short hostname, so chop off any
     # trailing domain name and explicity add any domain if set.
-    [ -n "$hostname" ] && echo "echo ${hostname%.$domain}${domain:+.$domain} > /proc/sys/kernel/hostname" > /tmp/net."$netif".hostname
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname%."$domain"}${domain:+.$domain}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
 }
 
 parse_option_121() {

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -28,7 +28,7 @@ do_dhcp_parallel() {
     # event for nfsroot
     # XXX add -V vendor class and option parsing per kernel
 
-    [ -e "/tmp/dhclient.$netif.pid" ] && return 0
+    [ -e "/tmp/dhclient.${netif}.pid" ] && return 0
 
     if ! iface_has_carrier "$netif"; then
         warn "No carrier detected on interface $netif"
@@ -121,8 +121,10 @@ do_ipv6auto() {
     wait_for_ipv6_auto "$netif"
     ret=$?
 
-    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
-
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
     return "$ret"
 }
 
@@ -134,7 +136,10 @@ do_ipv6link() {
     echo 0 > /proc/sys/net/ipv6/conf/"${netif}"/accept_redirects
     linkup "$netif"
 
-    [ -n "$hostname" ] && echo "echo $hostname > /proc/sys/kernel/hostname" > "/tmp/net.${netif}.hostname"
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
 
     return "$ret"
 }
@@ -187,8 +192,12 @@ do_static() {
         ip addr add "$ip/$mask" ${srv:+peer "$srv"} brd + dev "$netif"
     fi
 
-    [ -n "$gw" ] && echo "ip route replace default via '$gw' dev '$netif'" > "/tmp/net.$netif.gw"
-    [ -n "$hostname" ] && echo "echo '$hostname' > /proc/sys/kernel/hostname" > "/tmp/net.$netif.hostname"
+    [ -n "$gw" ] && printf "ip route replace default via %q dev %q\n" "$gw" "$netif" > "/tmp/net.${netif}.gw"
+
+    if [ -n "$hostname" ]; then
+        safe_hostname=$(printf '%s' "${hostname}")
+        printf 'echo %q > /proc/sys/kernel/hostname\n' "$safe_hostname" > /tmp/net."$netif".hostname
+    fi
 
     return 0
 }
@@ -417,7 +426,7 @@ fi
 [ -n "$2" -a "$2" = "-m" ] && [ -z "$netroot" ] && manualup="$2"
 
 if [ -n "$manualup" ]; then
-    : > "/tmp/net.$netif.manualup"
+    : > "/tmp/net.${netif}.manualup"
     rm -f "/tmp/net.${netif}.did-setup"
 else
     [ -e "/tmp/net.${netif}.did-setup" ] && exit 0
@@ -458,7 +467,7 @@ for p in $(getargs ip=); do
     # Store config for later use
     for i in ip srv gw mask hostname macaddr mtu dns1 dns2; do
         eval '[ "$'$i'" ] && echo '$i'="$'$i'"'
-    done > "/tmp/net.$netif.override"
+    done > "/tmp/net.${netif}.override"
 
     for autoopt in $(str_replace "$autoconf" "," " "); do
         case $autoopt in
@@ -492,7 +501,7 @@ for p in $(getargs ip=); do
     # setup nameserver
     for s in "$dns1" "$dns2" $(getargs nameserver); do
         [ -n "$s" ] || continue
-        echo "nameserver $s" >> "/tmp/net.$netif.resolv.conf"
+        echo "nameserver $s" >> "/tmp/net.${netif}.resolv.conf"
     done
 
     if [ $ret -eq 0 ]; then
@@ -546,7 +555,7 @@ if [ -z "$NO_AUTO_DHCP" ] && [ ! -e "/tmp/net.${netif}.up" ]; then
 
     for s in $(getargs nameserver); do
         [ -n "$s" ] || continue
-        echo "nameserver $s" >> "/tmp/net.$netif.resolv.conf"
+        echo "nameserver $s" >> "/tmp/net.${netif}.resolv.conf"
     done
 
     if [ "$ret" -eq 0 ] && [ -n "$(ls "/tmp/leaseinfo.${netif}"* 2> /dev/null)" ]; then

--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -127,8 +127,13 @@ setup_net() {
     [ -e "/tmp/net.ifaces" ] && read -r IFACES < /tmp/net.ifaces
     [ -z "$IFACES" ] && IFACES="$netif"
     # run the scripts written by ifup
-    # shellcheck disable=SC1090
-    [ -e /tmp/net."$netif".hostname ] && . /tmp/net."$netif".hostname
+    if [ -e /tmp/net."$netif".hostname ]; then
+        if grep -qE '[$`;&|(]' /tmp/net."$netif".hostname 2> /dev/null; then
+            warn "setup_net $netif: /tmp/net.$netif.hostname contains suspicious shell metacharacters"
+        fi
+        # shellcheck disable=SC1090
+        . /tmp/net."$netif".hostname
+    fi
     # shellcheck disable=SC1090
     [ -e /tmp/net."$netif".override ] && . /tmp/net."$netif".override
     # shellcheck disable=SC1090

--- a/modules.d/95iscsi/iscsiroot.sh
+++ b/modules.d/95iscsi/iscsiroot.sh
@@ -145,7 +145,7 @@ handle_netroot() {
 
     if [ -z "$iscsi_initiator" ] && [ -f /sys/firmware/ibft/initiator/initiator-name ] && ! [ -f /tmp/iscsi_set_initiator ]; then
         iscsi_initiator=$(while read -r line || [ -n "$line" ]; do echo "$line"; done < /sys/firmware/ibft/initiator/initiator-name)
-        echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+        printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
@@ -166,7 +166,7 @@ handle_netroot() {
 
     if [ -z "$iscsi_initiator" ]; then
         iscsi_initiator=$(iscsi-iname)
-        echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+        printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi
@@ -190,7 +190,7 @@ handle_netroot() {
         iscsi_lun=0
     fi
 
-    echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+    printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
     ln -fs /run/initiatorname.iscsi /dev/.initiatorname.iscsi
     if ! [ -e /etc/iscsi/initiatorname.iscsi ]; then
         mkdir -p /etc/iscsi
@@ -211,14 +211,14 @@ handle_netroot() {
 
     if [ "$root" = "dhcp" ] || [ "$netroot" = "dhcp" ]; then
         # if root is not specified try to mount the whole iSCSI LUN
-        printf 'SYMLINK=="disk/by-path/*-iscsi-*-%s", SYMLINK+="root"\n' "$iscsi_lun" >> /etc/udev/rules.d/99-iscsi-root.rules
+        printf 'SYMLINK=="disk/by-path/*-iscsi-*-%s", SYMLINK+="root"\n' "$(printf '%s' "$iscsi_lun" | tr -d '"')" >> /etc/udev/rules.d/99-iscsi-root.rules
         udevadm control --reload
         write_fs_tab /dev/root
         wait_for_dev -n /dev/root
 
         # install mount script
         [ -z "$DRACUT_SYSTEMD" ] \
-            && echo "iscsi_lun=$iscsi_lun . /bin/mount-lun.sh " > "$hookdir"/mount/01-$$-iscsi.sh
+            && printf 'iscsi_lun=%q . /bin/mount-lun.sh\n' "$iscsi_lun" > "$hookdir"/mount/01-$$-iscsi.sh
     fi
 
     if strglobin "$iscsi_target_ip" '*:*:*' && ! strglobin "$iscsi_target_ip" '['; then

--- a/modules.d/95iscsi/parse-iscsiroot.sh
+++ b/modules.d/95iscsi/parse-iscsiroot.sh
@@ -87,7 +87,7 @@ if [ -n "$iscsi_firmware" ]; then
     echo "${DRACUT_SYSTEMD+systemctl is-active initrd-root-device.target || }[ -f '/tmp/iscsistarted-firmware' ]" > "$hookdir"/initqueue/finished/iscsi_started.sh
     initqueue --unique --online /sbin/iscsiroot online "iscsi:" "$NEWROOT"
     initqueue --unique --onetime --timeout /sbin/iscsiroot timeout "iscsi:" "$NEWROOT"
-    initqueue --unique --onetime --settled /sbin/iscsiroot online "iscsi:" "'$NEWROOT'"
+    initqueue --unique --onetime --settled /sbin/iscsiroot online "iscsi:" "$NEWROOT"
 fi
 
 # ISCSI actually supported?
@@ -99,7 +99,7 @@ modprobe --all -b -q qla4xxx cxgb3i cxgb4i bnx2i be2iscsi
 
 if [ -n "$netroot" ] && [ "$root" != "/dev/root" ] && [ "$root" != "dhcp" ]; then
     if ! getargbool 1 rd.neednet > /dev/null || ! getarg "ip="; then
-        initqueue --unique --onetime --settled /sbin/iscsiroot dummy "'$netroot'" "'$NEWROOT'"
+        initqueue --unique --onetime --settled /sbin/iscsiroot dummy "$netroot" "$NEWROOT"
     fi
 fi
 

--- a/modules.d/95iscsi/parse-iscsiroot.sh
+++ b/modules.d/95iscsi/parse-iscsiroot.sh
@@ -105,7 +105,7 @@ fi
 
 if arg=$(getarg rd.iscsi.initiator -d iscsi_initiator=) && [ -n "$arg" ] && ! [ -f /run/initiatorname.iscsi ]; then
     iscsi_initiator=$arg
-    echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+    printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
     ln -fs /run/initiatorname.iscsi /dev/.initiatorname.iscsi
     rm -f /etc/iscsi/initiatorname.iscsi
     mkdir -p /etc/iscsi
@@ -121,7 +121,7 @@ fi
 if [ -z "$iscsi_initiator" ] && [ -f /sys/firmware/ibft/initiator/initiator-name ] && ! [ -f /tmp/iscsi_set_initiator ]; then
     iscsi_initiator=$(while read -r line || [ -n "$line" ]; do echo "$line"; done < /sys/firmware/ibft/initiator/initiator-name)
     if [ -n "$iscsi_initiator" ]; then
-        echo "InitiatorName=$iscsi_initiator" > /run/initiatorname.iscsi
+        printf 'InitiatorName=%q\n' "$iscsi_initiator" > /run/initiatorname.iscsi
         rm -f /etc/iscsi/initiatorname.iscsi
         mkdir -p /etc/iscsi
         ln -fs /run/initiatorname.iscsi /etc/iscsi/initiatorname.iscsi

--- a/modules.d/99base/initqueue.sh
+++ b/modules.d/99base/initqueue.sh
@@ -64,7 +64,8 @@ fi
     # shellcheck disable=SC2016
     [ -n "$onetime" ] && echo '[ -e "$job" ] && rm -f -- "$job"'
     [ -n "$env" ] && echo "$env"
-    echo "$exe" "$@"
+    printf '%q ' "$exe" "$@"
+    printf '\n'
 } > "/tmp/$$-${job}.sh"
 
 mv -f "/tmp/$$-${job}.sh" "$hookdir/initqueue${qname}/${job}.sh"


### PR DESCRIPTION
- **fix(network-legacy): replace `echo` writes with `printf` to prevent injection via DHCP**
- **fix(iscsi): replace `echo` writes with `printf` to prevent variable injection**
- **reverted: dummy placeholder patch**
- **fix(network): warn on suspicious shell metacharacters in hostname file**
- **fix(base): escape arguments in initqueue hook script generation**

<!-- issue-commentator = {"comment-id":"4686187910"} -->