### PR TITLE
rhel 9 fix 210940

### DIFF
--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -374,12 +374,18 @@ splitsep() {
 
     while [ -n "$str" -a "$#" -gt 1 ]; do
         tmp="${str%%$sep*}"
-        eval "$1='${tmp}'"
+        local -n _splitsep_ref="$1"
+        _splitsep_ref="$tmp"
+        unset -n _splitsep_ref
         str="${str#"$tmp"}"
         str="${str#$sep}"
         shift
     done
-    [ -n "$str" -a -n "$1" ] && eval "$1='$str'"
+    if [ -n "$str" -a -n "$1" ]; then
+        local -n _splitsep_ref="$1"
+        _splitsep_ref="$str"
+        unset -n _splitsep_ref
+    fi
     debug_on
     return 0
 }
@@ -1016,14 +1022,13 @@ emergency_shell() {
 }
 
 # Retain the values of these variables but ensure that they are unexported
-# This is a POSIX-compliant equivalent of bash's "export -n"
 export_n() {
     local var
     local val
     for var in "$@"; do
-        eval val=\$$var
-        unset $var
-        [ -n "$val" ] && eval "$var=\"$val\""
+        val="${!var}"
+        unset "$var"
+        [ -n "$val" ] && printf -v "$var" '%s' "$val"
     done
 }
 

--- a/modules.d/99base/dracut-lib.sh
+++ b/modules.d/99base/dracut-lib.sh
@@ -451,7 +451,7 @@ die() {
     } > /dev/kmsg
 
     {
-        echo "warn dracut: FATAL: \"$*\""
+        printf 'warn dracut: FATAL: %q\n' "$*"
         echo "warn dracut: Refusing to continue"
     } >> $hookdir/emergency/01-die.sh
     [ -d /run/initramfs ] || mkdir -p -- /run/initramfs


### PR DESCRIPTION
- **fix(base): escape die() message in emergency hook script**
- **fix(base): replace eval with safe variable indirection in splitsep and export_n**

<!-- issue-commentator = {"comment-id":"5280586128"} -->