### PR TITLE
fix(qemu): add missing bochs module explicitly

### DIFF
--- a/modules.d/90qemu/module-setup.sh
+++ b/modules.d/90qemu/module-setup.sh
@@ -19,4 +19,7 @@ installkernel() {
         virtio_scsi virtio_console virtio_rng virtio_mem \
         spapr-vscsi \
         qemu_fw_cfg
+
+    # needed for displaying console properly
+    hostonly='' instmods bochs
 }


### PR DESCRIPTION
As it is needed to display console properly, and doesn't get detected in some cases.

(cherry picked from commit 6328318f17933798a4a1a4e3b974b27070a470ad)

Resolves: RHEL-217597

<!-- issue-commentator = {"comment-id":"5281265060"} -->